### PR TITLE
Fix pasting into a command

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ loader_version=0.17.3
 loom_version=1.12-SNAPSHOT
 
 # Mod Properties
-mod_version = 0.1.0
+mod_version = 0.1.1
 maven_group = net.ramgames
 archives_base_name = NoCommandChatLimit
 

--- a/src/main/java/net/ramixin/slashlength/client/mixins/TextFieldWidgetMixin.java
+++ b/src/main/java/net/ramixin/slashlength/client/mixins/TextFieldWidgetMixin.java
@@ -12,7 +12,6 @@ import org.spongepowered.asm.mixin.injection.At;
 @Mixin(TextFieldWidget.class)
 public abstract class TextFieldWidgetMixin implements TextFieldWidgetDuck {
 
-    @Shadow public abstract void setMaxLength(int maxLength);
     @Shadow private int selectionStart;
     @Shadow private int selectionEnd;
 
@@ -28,7 +27,7 @@ public abstract class TextFieldWidgetMixin implements TextFieldWidgetDuck {
             } else isCommand = text.startsWith("/");
         }
         if (isCommand) instance.setMaxLength(Integer.MAX_VALUE);
-        else this.setMaxLength(256);
+        else instance.setMaxLength(256);
         original.call(instance, text);
     }
 

--- a/src/main/java/net/ramixin/slashlength/client/mixins/TextFieldWidgetMixin.java
+++ b/src/main/java/net/ramixin/slashlength/client/mixins/TextFieldWidgetMixin.java
@@ -13,14 +13,22 @@ import org.spongepowered.asm.mixin.injection.At;
 public abstract class TextFieldWidgetMixin implements TextFieldWidgetDuck {
 
     @Shadow public abstract void setMaxLength(int maxLength);
+    @Shadow private int selectionStart;
+    @Shadow private int selectionEnd;
 
     @Unique
     private boolean isChatBox = false;
 
     @WrapOperation(method = "keyPressed", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/widget/TextFieldWidget;write(Ljava/lang/String;)V", ordinal = 0))
     private void preventTruncationIfPastingCommand(TextFieldWidget instance, String text, Operation<Void> original) {
-        if(isChatBox && text.startsWith("/")) setMaxLength(Integer.MAX_VALUE);
-        else setMaxLength(256);
+        boolean isCommand = false;
+        if(isChatBox) {
+            if (Math.min(Math.min(this.selectionStart, this.selectionEnd), instance.getCursor()) > 0) {
+                isCommand = instance.getText().startsWith("/");
+            } else isCommand = text.startsWith("/");
+        }
+        if (isCommand) instance.setMaxLength(Integer.MAX_VALUE);
+        else this.setMaxLength(256);
         original.call(instance, text);
     }
 


### PR DESCRIPTION
[Version 0.1.0](https://github.com/Ramixin/SlashLength/commit/4054542a30c0fed07f1e5468b0b4e1584bca33b1) no longer allows exceeding Vanilla's imposed 256 character limit when pasting text that does not start with a '/' into an existing command in the chat bar.

From [TextFieldWidgetMixin.java Line 22](https://github.com/Ramixin/SlashLength/blob/449688d103df11621067a2892cf8f80180a5566a/src/main/java/net/ramixin/slashlength/client/mixins/TextFieldWidgetMixin.java#L22):
```java
if(isChatBox && text.startsWith("/")) setMaxLength(Integer.MAX_VALUE);
else ...
```
This only checks the text in the clipboard as opposed to the text drafted in the chat bar, preventing - for example - pasting some SNBT as part of an existing `/data merge` command that is already being drafted in the chat bar.

To fix this, I've slightly modified the check to make sure the first character after pasting is still a forward slash '/'.

I have not incremented the mod version or anything else, just this. Thanks for the mod 😄 